### PR TITLE
feat: Create index.html to link to all topic pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Engineering Topics</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #F0F4F8;
+            color: #1E293B;
+        }
+        .gradient-text {
+            background: linear-gradient(90deg, #58508d, #bc5090);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .card {
+            background-color: white;
+            border-radius: 0.75rem;
+            padding: 1.5rem;
+            box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.05), 0 4px 6px -4px rgb(0 0 0 / 0.05);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            display: flex;
+            flex-direction: column;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+        }
+        .card-content {
+            flex-grow: 1;
+        }
+        .card-link {
+            margin-top: auto;
+            padding-top: 1rem;
+        }
+    </style>
+</head>
+<body class="antialiased">
+    <header class="bg-white sticky top-0 z-50 shadow-md">
+        <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <div class="text-2xl font-bold text-gray-800">
+                <span class="gradient-text">Data Engineering Concepts</span>
+            </div>
+        </nav>
+    </header>
+    <main class="container mx-auto px-6 py-12">
+        <section id="hero" class="text-center mb-20">
+            <h1 class="text-4xl md:text-6xl font-black mb-4 leading-tight">A Collection of Data Engineering Topics</h1>
+            <p class="text-lg text-gray-600 max-w-3xl mx-auto">An overview of various technologies and concepts in the data engineering landscape. Click on a topic to learn more.</p>
+        </section>
+        <div id="topics-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Databricks Auto Loader</h3>
+                    <p class="text-gray-600">An interactive guide to Databricks Auto Loader, covering its architecture and file discovery modes.</p>
+                </div>
+                <div class="card-link">
+                    <a href="autoloader.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Google BigQuery</h3>
+                    <p class="text-gray-600">A visual deep dive into the core concepts of BigQuery that enable massive scale and cost efficiency.</p>
+                </div>
+                <div class="card-link">
+                    <a href="bigquery.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Google Bigtable</h3>
+                    <p class="text-gray-600">Explore the essential concepts behind Bigtable's schema design for efficiency and performance.</p>
+                </div>
+                <div class="card-link">
+                    <a href="bigtable.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Modern Fintech Data Platform</h3>
+                    <p class="text-gray-600">An infographic visualizing the architecture of a high-speed data platform for portfolio analytics.</p>
+                </div>
+                <div class="card-link">
+                    <a href="case1.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Google Cloud Composer</h3>
+                    <p class="text-gray-600">A visual exploration of the components and concepts for building pipelines with Apache Airflow.</p>
+                </div>
+                <div class="card-link">
+                    <a href="composer.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Databricks & Lakehouse</h3>
+                    <p class="text-gray-600">An introduction to the Databricks platform and the Lakehouse architecture for unified data analytics.</p>
+                </div>
+                <div class="card-link">
+                    <a href="databricks.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Databricks Platform Deep Dive</h3>
+                    <p class="text-gray-600">A visual guide to the core components of the Databricks Lakehouse Platform, from Spark to Delta Lake.</p>
+                </div>
+                <div class="card-link">
+                    <a href="databricks_platform.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Google Cloud Dataflow</h3>
+                    <p class="text-gray-600">A deep dive into the Apache Beam programming model used by Cloud Dataflow for stream and batch processing.</p>
+                </div>
+                <div class="card-link">
+                    <a href="dataflow.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Google Cloud Dataproc</h3>
+                    <p class="text-gray-600">A visual guide to Google's managed service for Spark, Hadoop, and other open-source data frameworks.</p>
+                </div>
+                <div class="card-link">
+                    <a href="dataproc.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Dimensional Modeling</h3>
+                    <p class="text-gray-600">Learn about dimensional modeling techniques and best practices for designing Lakehouse pipelines.</p>
+                </div>
+                <div class="card-link">
+                    <a href="dim_model.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Google Kubernetes Engine (GKE)</h3>
+                    <p class="text-gray-600">A visual deep dive into the fundamental components of GKE, Google's managed Kubernetes service.</p>
+                </div>
+                <div class="card-link">
+                    <a href="gke.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">Spark Internals & Tuning</h3>
+                    <p class="text-gray-600">Understand Spark's internal architecture to write more efficient and performant applications.</p>
+                </div>
+                <div class="card-link">
+                    <a href="spark_internals.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <h3 class="text-xl font-bold text-gray-800 mb-2">SQL Querying & Tuning</h3>
+                    <p class="text-gray-600">Learn advanced SQL features and tuning strategies for querying large datasets efficiently.</p>
+                </div>
+                <div class="card-link">
+                    <a href="sqltuning.html" class="font-semibold text-[#58508d] hover:text-[#bc5090]">Learn more &rarr;</a>
+                </div>
+            </div>
+        </div>
+    </main>
+    <footer class="bg-gray-800 text-white text-center p-6 mt-16">
+        <p>&copy; 2025 Data Engineering Guides. An illustrative web application.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
This change introduces a new `index.html` file that acts as a central landing page for all the data engineering topic pages.

It includes a brief summary for each topic and a direct link to the corresponding page. The styling is consistent with the existing pages, using Tailwind CSS and a shared color scheme to provide a unified user experience.