### PR TITLE
feat: Create index.html and add back-to-home links

### DIFF
--- a/autoloader.html
+++ b/autoloader.html
@@ -75,6 +75,7 @@
                     <h1 class="text-2xl font-bold text-slate-800">Auto Loader Deep Dive</h1>
                 </div>
                 <div class="hidden md:flex items-center space-x-6 text-sm font-medium text-slate-600">
+                    <a href="index.html" class="text-slate-600 hover:text-teal-600 transition-colors">Home</a>
                     <a href="#architecture" class="hover:text-teal-600 transition-colors">Architecture</a>
                     <a href="#modes" class="hover:text-teal-600 transition-colors">Ingestion Modes</a>
                     <a href="#efficiency" class="hover:text-teal-600 transition-colors">Efficiency</a>

--- a/bigquery.html
+++ b/bigquery.html
@@ -245,7 +245,7 @@
     </script>
 </head>
 <body class="p-8">
-
+    <a href="index.html" class="text-gray-600 hover:text-purple-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
     <h1 class="text-4xl font-extrabold text-gray-800 mb-6 flex items-center">
         <svg class="w-8 h-8 mr-3 text-purple-600" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
         BigQuery Schema & Performance Essentials

--- a/bigtable.html
+++ b/bigtable.html
@@ -290,7 +290,7 @@
     </script>
 </head>
 <body class="p-8">
-
+    <a href="index.html" class="text-gray-600 hover:text-blue-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
     <h1 class="text-4xl font-extrabold text-gray-800 mb-6 flex items-center">
         <svg class="w-8 h-8 mr-3 text-blue-600" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4zm5 9a1 1 0 10-2 0 1 1 0 002 0zM7 5a1 1 0 00-1 1v4a1 1 0 001 1h6a1 1 0 001-1V6a1 1 0 00-1-1H7z" clip-rule="evenodd"></path></svg>
         Bigtable Schema Design Essentials

--- a/case1.html
+++ b/case1.html
@@ -75,6 +75,7 @@
                 <span class="gradient-text">Fintech Data Platforms</span>
             </div>
             <ul class="flex space-x-6 text-gray-600 font-medium">
+                <li><a href="index.html" class="text-gray-600 hover:text-[#bc5090]">Home</a></li>
                 <li><a href="#ingestion" class="hover:text-[#bc5090]">Ingestion</a></li>
                 <li><a href="#lakehouse" class="hover:text-[#bc5090]">Lakehouse</a></li>
                 <li><a href="#consumption" class="hover:text-[#bc5090]">Consumption</a></li>

--- a/composer.html
+++ b/composer.html
@@ -272,7 +272,7 @@
     </script>
 </head>
 <body class="p-8">
-
+    <a href="index.html" class="text-gray-600 hover:text-teal-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
     <h1 class="text-4xl font-extrabold text-gray-800 mb-6 flex items-center">
         <svg class="w-8 h-8 mr-3 text-teal-600" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-7-9a1 1 0 000 2h3.586l-1.293 1.293a1 1 0 101.414 1.414l3-3a1 1 0 000-1.414l-3-3a1 1 0 00-1.414 1.414l1.293 1.293H3z" clip-rule="evenodd"></path></svg>
         Cloud Composer (Apache Airflow) Essentials

--- a/databricks.html
+++ b/databricks.html
@@ -89,6 +89,7 @@
 </head>
 <body class="p-4 sm:p-6 md:p-8">
     <div class="container">
+        <a href="index.html" class="text-gray-600 hover:text-indigo-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
         <h1 class="text-4xl font-bold text-center mb-8 text-indigo-700">Understanding Databricks & Lakehouse Architecture</h1>
 
         <!-- What is Databricks? -->

--- a/databricks_platform.html
+++ b/databricks_platform.html
@@ -287,7 +287,7 @@
     </script>
 </head>
 <body class="p-8">
-
+    <a href="index.html" class="text-gray-600 hover:text-gray-800 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
     <h1 class="text-4xl font-extrabold text-gray-800 mb-6 flex items-center">
         <svg class="w-8 h-8 mr-3 text-gray-600" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a8 8 0 00-8 8c0 1.25.176 2.45.518 3.559L10 16.5l7.482-2.941A8 8 0 0018 10a8 8 0 00-8-8zm-1.5 8a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zM10 18a8 8 0 100-16 8 8 0 000 16zM10 5a1 1 0 00-1 1v1a1 1 0 002 0V6a1 1 0 00-1-1zM5 10a1 1 0 000 2h1a1 1 0 000-2H5zM14 10a1 1 0 000 2h1a1 1 0 000-2h-1z"></path></svg>
         Databricks Lakehouse Platform Visual Deep Dive

--- a/dataflow.html
+++ b/dataflow.html
@@ -271,7 +271,7 @@
     </script>
 </head>
 <body class="p-8">
-
+    <a href="index.html" class="text-gray-600 hover:text-indigo-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
     <h1 class="text-4xl font-extrabold text-gray-800 mb-6 flex items-center">
         <svg class="w-8 h-8 mr-3 text-indigo-600" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
         Cloud Dataflow (Apache Beam) Pipeline Essentials

--- a/dataproc.html
+++ b/dataproc.html
@@ -261,7 +261,7 @@
     </script>
 </head>
 <body class="p-8">
-
+    <a href="index.html" class="text-gray-600 hover:text-yellow-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
     <h1 class="text-4xl font-extrabold text-gray-800 mb-6 flex items-center">
         <svg class="w-8 h-8 mr-3 text-yellow-600" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM5 9a1 1 0 000 2h10a1 1 0 100-2H5z" clip-rule="evenodd"></path></svg>
         Google Cloud Dataproc Visual Deep Dive

--- a/dim_model.html
+++ b/dim_model.html
@@ -65,6 +65,7 @@
 </head>
 <body class="p-4 sm:p-6 md:p-8">
     <div class="container">
+        <a href="index.html" class="text-gray-600 hover:text-sky-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
         <h1 class="text-4xl font-bold text-center mb-8 text-sky-800">Dimensional Modeling & Lakehouse Pipeline Design</h1>
 
         <!-- Principles of Dimensional Modeling -->

--- a/gke.html
+++ b/gke.html
@@ -260,7 +260,7 @@
     </script>
 </head>
 <body class="p-8">
-
+    <a href="index.html" class="text-gray-600 hover:text-blue-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
     <h1 class="text-4xl font-extrabold text-gray-800 mb-6 flex items-center">
         <svg class="w-8 h-8 mr-3 text-blue-600" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM13 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2h-2zM13 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2h-2z"></path></svg>
         Google Kubernetes Engine (GKE) Visual Deep Dive

--- a/spark_internals.html
+++ b/spark_internals.html
@@ -86,6 +86,7 @@
 </head>
 <body class="p-4 sm:p-6 md:p-8">
     <div class="container">
+        <a href="index.html" class="text-gray-600 hover:text-teal-700 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
         <h1 class="text-4xl font-bold text-center mb-8 text-teal-700">Spark Internals, Performance & Best Practices</h1>
 
         <!-- Spark Internals -->

--- a/sqltuning.html
+++ b/sqltuning.html
@@ -75,6 +75,7 @@
 </head>
 <body class="p-4 sm:p-6 md:p-8">
     <div class="container">
+        <a href="index.html" class="text-gray-600 hover:text-emerald-600 hover:underline font-semibold mb-6 inline-block">&larr; Back to Home</a>
         <h1 class="text-4xl font-bold text-center mb-8 text-emerald-800">SQL Querying & Tuning for Large Datasets</h1>
 
         <!-- Introduction -->


### PR DESCRIPTION
This change introduces a new `index.html` file that acts as a central landing page for all the data engineering topic pages. It includes a brief summary for each topic and a direct link to the corresponding page.

Additionally, this change adds a 'Back to Home' link to each of the topic pages to ensure seamless navigation, and standardizes the styling of these links for a consistent user experience.